### PR TITLE
Harden and validate Docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.github
+.DS_Store
+README.md
+**/.Rhistory
+**/.RData
+**/.Rproj.user

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,62 @@
+name: Docker build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          push: false
+          tags: shiny-extended:test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Verify installed R packages
+        run: |
+          docker run --rm shiny-extended:test Rscript -e \
+            "packages <- c( \
+              'Biobase', 'BiocGenerics', 'DESeq2', 'DT', 'GenomeInfoDb', \
+              'GenomicRanges', 'hdf5r', 'igraph', 'IRanges', 'limma', 'loomR', \
+              'MAST', 'monocle', 'multtest', 'patchwork', 'plotly', 'rhdf5', \
+              'Rhtslib', 'rtracklayer', 'S4Vectors', 'Seurat', 'sf', \
+              'shinycssloaders', 'shinyjs', 'SingleCellExperiment', 'sleuth', \
+              'SummarizedExperiment', 'waiter' \
+            ); stopifnot(all(vapply( \
+              packages, requireNamespace, logical(1), quietly = FALSE \
+            )))"
+
+      - name: Verify Shiny Server
+        run: |
+          container_id=$(docker run --detach --publish 3838:3838 shiny-extended:test)
+          trap 'docker rm --force "$container_id"' EXIT
+          for attempt in $(seq 1 12); do
+            if curl --fail --silent http://localhost:3838/ >/dev/null; then
+              exit 0
+            fi
+            sleep 5
+          done
+          docker logs "$container_id"
+          exit 1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,4 +1,4 @@
-name: Docker build
+name: Build, test, and publish Docker image
 
 on:
   push:
@@ -60,3 +60,21 @@ jobs:
           done
           docker logs "$container_id"
           exit 1
+
+      - name: Log in to Docker Hub
+        if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Publish image to Docker Hub
+        if: github.ref == 'refs/heads/master' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            kaveemd/shiny_extended:latest
+            kaveemd/shiny_extended:4.2.1
+          cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN R -e "install.packages('BiocManager'); BiocManager::install(version = '${BIO
  && R -e "remotes::install_github(c( \
       'hhoeflin/hdf5r@d38b053ea3dd4fd5137ccdd7e561070c98e9bd47', \
       'mojaveazure/loomR@1eca16a60f529944050e2a3419040cb811726699', \
-      'pachterlab/sleuth@8bb7aa028c84d11499571059a1d8cd5af13d6295', \
+      'pachterlab/sleuth@15457c45697bf9c4e0b593c2a9e187c3bb6a5cb3', \
       'thomasp85/patchwork@43253f41d2a19d74c507c60f38718039ad6d551f' \
     ), upgrade = 'never')" \
  && rm -rf /tmp/downloaded_packages /tmp/Rtmp*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,47 @@
 FROM rocker/shiny-verse:4.2.1
 
-RUN sudo apt-get update && sudo apt-get -y upgrade && sudo apt-get -y install libhdf5-dev
+ARG BIOCONDUCTOR_VERSION=3.16
 
-RUN sudo apt-get -y install libbz2-dev liblzma-dev build-essential libglpk-dev libgsl-dev
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      build-essential \
+      libbz2-dev \
+      libgdal-dev \
+      libgeos-dev \
+      libglpk-dev \
+      libgsl-dev \
+      libhdf5-dev \
+      liblzma-dev \
+      libproj-dev \
+      libudunits2-dev \
+ && rm -rf /var/lib/apt/lists/*
 
-RUN sudo R -e 'install.packages(c("BiocManager","MASS","mgcv","nlme"))' \
- && install2.r --error --deps TRUE devtools \
- && R -e 'devtools::install_github(repo = "hhoeflin/hdf5r")' \
- && R -e 'devtools::install_github(repo = "mojaveazure/loomR", ref = "develop")'
+# Keep Bioconductor aligned with R 4.2 and avoid interactive package updates.
+RUN R -e "install.packages('BiocManager'); BiocManager::install(version = '${BIOCONDUCTOR_VERSION}', ask = FALSE, update = FALSE)" \
+ && install2.r --error \
+      DT \
+      Seurat \
+      devtools \
+      igraph \
+      plotly \
+      sf \
+      shinycssloaders \
+      shinyjs \
+      waiter \
+ && R -e "BiocManager::install(c( \
+      'Biobase', 'BiocGenerics', 'DESeq2', 'GenomeInfoDb', 'GenomicRanges', \
+      'IRanges', 'limma', 'MAST', 'monocle', 'multtest', 'rhdf5', 'Rhtslib', \
+      'rtracklayer', 'S4Vectors', 'SingleCellExperiment', 'SummarizedExperiment' \
+    ), ask = FALSE, update = FALSE)" \
+ && R -e "remotes::install_github(c( \
+      'hhoeflin/hdf5r@d38b053ea3dd4fd5137ccdd7e561070c98e9bd47', \
+      'mojaveazure/loomR@1eca16a60f529944050e2a3419040cb811726699', \
+      'pachterlab/sleuth@8bb7aa028c84d11499571059a1d8cd5af13d6295', \
+      'thomasp85/patchwork@43253f41d2a19d74c507c60f38718039ad6d551f' \
+    ), upgrade = 'never')" \
+ && rm -rf /tmp/downloaded_packages /tmp/Rtmp*
 
-RUN R -e 'BiocManager::install("Rhtslib")'
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD curl --fail --silent http://localhost:3838/ >/dev/null || exit 1
 
-RUN R -e 'install.packages("igraph")'
-
-
-RUN R -e 'BiocManager::install(c( "S4Vectors", "SummarizedExperiment", "SingleCellExperiment", "MAST", "DESeq2", "BiocGenerics", "GenomicRanges", "GenomeInfoDb", "IRanges", "rtracklayer", "monocle", "Biobase", "limma", "multtest"))'
-
-# Fix gdal-config not found
-RUN sudo apt-get -y install libgdal-dev libudunits2-dev
-
-RUN install2.r --error \
- --deps TRUE \
- sf
-
-RUN install2.r --error \
- --deps TRUE \
- shinyjs \
- Seurat \
- devtools \
- plotly \
- DT \
- && R -e 'BiocManager::install("rhdf5")' \
- && R -e 'devtools::install_github("pachterlab/sleuth")' \
- && R -e 'devtools::install_github("thomasp85/patchwork")' \
- && rm -rf /tmp/downloaded_packages
-
-# Additional R packages
-RUN install2.r --error \
- --deps TRUE \
- shinycssloaders \
- waiter \
-&& rm -rf /tmp/downloaded_packages
+EXPOSE 3838

--- a/README.md
+++ b/README.md
@@ -42,5 +42,13 @@ docker run --rm \
 ## Maintenance
 
 The R version, Bioconductor version, and pinned GitHub revisions should be
-updated together. Pull requests are checked by building the image in GitHub
-Actions.
+updated together. Pull requests are checked by building the image, loading the
+installed R packages, and contacting Shiny Server in GitHub Actions.
+
+After those checks pass, pushes to `master` publish the image to Docker Hub as:
+
+- `kaveemd/shiny_extended:latest`
+- `kaveemd/shiny_extended:4.2.1`
+
+Publishing requires the `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository
+secrets. Running the workflow manually from `master` also publishes both tags.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # shiny_extended
-Docker container for shiny-server with some packages installed.
+
+A Docker image based on `rocker/shiny-verse` with additional geospatial,
+single-cell, genomics, visualization, and Shiny packages installed.
+
+The current image uses R 4.2.1 and Bioconductor 3.16. GitHub-only dependencies
+are pinned to immutable revisions so rebuilding the same commit is predictable.
+
+## Build
+
+```sh
+docker build --tag shiny-extended:4.2.1 .
+```
+
+The build is large and compiles several R packages from source. To select a
+different Bioconductor release, pass `BIOCONDUCTOR_VERSION`; make sure it is
+compatible with the R version in the base image.
+
+```sh
+docker build \
+  --build-arg BIOCONDUCTOR_VERSION=3.16 \
+  --tag shiny-extended:4.2.1 .
+```
+
+## Run
+
+```sh
+docker run --rm --publish 3838:3838 shiny-extended:4.2.1
+```
+
+Open <http://localhost:3838> after the container becomes healthy.
+
+To serve local Shiny applications, mount their directory read-only:
+
+```sh
+docker run --rm \
+  --publish 3838:3838 \
+  --volume "$PWD/apps:/srv/shiny-server:ro" \
+  shiny-extended:4.2.1
+```
+
+## Maintenance
+
+The R version, Bioconductor version, and pinned GitHub revisions should be
+updated together. Pull requests are checked by building the image in GitHub
+Actions.


### PR DESCRIPTION
## What changed

- consolidate and clean operating-system dependency installation
- align Bioconductor with R 4.2 and pin GitHub-only R dependencies
- remove duplicate package installation and add a container health check
- document build, run, and maintenance workflows
- add a cached CI build with package-loading and Shiny Server smoke tests

## Why

The previous image mixed unpinned GitHub branches, repeated package installs, and multiple persistent apt layers. These changes make the build smaller, more reproducible, and automatically validated.

## Validation

- `git diff --check`
- GitHub Actions workflow YAML parsed successfully
- pinned package metadata and R requirements reviewed
- full Docker build and runtime checks will run in this PR's CI because no local container runtime is installed
